### PR TITLE
Audit filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var auditLogger;
+var auditConfig;
 var defaultLogger = require('./lib/defaultLogger');
 var loopbackHook = require('./lib/loopbackHook');
 
 module.exports = function (app, config) {
+
+    if (Object.keys(config).length != 0 || config.constructor != Object)
+        auditConfig = config;
 
     app = app || defaultLogger;
     var hook;
@@ -16,7 +20,7 @@ module.exports = function (app, config) {
             auditLogger = defaultLogger;
         }
 
-        loopbackHook.init(app, config, auditLogger);
+        loopbackHook.init(app, auditConfig, auditLogger);
 
         return;
     } else {

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -25,15 +25,20 @@ exports.init = function (app, config, auditLogger) {
         if (auditLog.arguments.args.res) {
             delete auditLog.arguments.args.res;
         }
+        // fix authorizedRoles with for JSON invalid keys '$...'
+        if (auditLog.arguments.args.options && auditLog.arguments.args.options.authorizedRoles) {
+            auditLog.arguments.args.options.authorizedRoles = Object.keys(auditLog.arguments.args.options.authorizedRoles);
+        }
 
-        // use loopbacks toJSON to remove circular references from models
-        auditLog.result = Array.isArray(context.result)
-            ? context.result.map(function (entry) { return entry.toJSON(); })
-            : ((context.result && context.result.toJSON) ? context.result.toJSON() : {});
+        auditLog.result = Array.isArray(context.result) ?
+            context.result.map(function (entry) {
+                return entry.toJSON();
+            }) : ((context.result && context.result.toJSON) ?
+                context.result.toJSON() : {});
         auditLog.error = context.error || {};
-        auditLog.status = context.error
-            ? (context.error.statusCode || context.error.status || context.res.statusCode)
-            : (context.result && Object.keys(context.result) > 0 ? 200 : 204);
+        auditLog.status = context.error ?
+            (context.error.statusCode || context.error.status || context.res.statusCode) :
+            (context.result && Object.keys(context.result) > 0 ? 200 : 204);
 
         var currentUser = {};
 
@@ -44,11 +49,8 @@ exports.init = function (app, config, auditLogger) {
                 undefined;
             auditLog.user = currentUser;
 
-            // $ and . are not allowed as keys in mongo, so escape them all
-            auditLog = JSON.parse(JSON.stringify(auditLog).replace(/\$/g, '___').replace(/\./g, '__'));
-
             process.nextTick(function () {
-                auditLogger.info({'log': auditLog});
+                auditLogger.info({ 'log': auditLog });
             });
         };
 
@@ -81,11 +83,16 @@ exports.init = function (app, config, auditLogger) {
         }
     }
 
+    function filter(context) {
+        return !config || !config.filter || config.filter(context);
+    }
+
     var models = app.models();
     models.forEach(function (Model) {
 
         Model.afterRemote('**', function (context, unused, next) {
-            log(context);
+            if (filter(context))
+                log(context);
             next();
         });
         Model.afterRemoteError('**', function (context, next) {


### PR DESCRIPTION
Add support for filtration of context before logging. This can be useful to avoid auditing query function like find and findById, which can be filtered by excluding requests with GET action.