### PR TITLE
Enabling find user in models that extend User model and log remote methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var auditLogger;
+var auditConfig;
 var defaultLogger = require('./lib/defaultLogger');
 var loopbackHook = require('./lib/loopbackHook');
 
 module.exports = function (app, config) {
+
+    if (Object.keys(config).length != 0 || config.constructor != Object)
+        auditConfig = config;
 
     app = app || defaultLogger;
     var hook;
@@ -16,7 +20,7 @@ module.exports = function (app, config) {
             auditLogger = defaultLogger;
         }
 
-        loopbackHook.init(app, config, auditLogger);
+        loopbackHook.init(app, auditConfig, auditLogger);
 
         return;
     } else {

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -30,7 +30,8 @@ exports.init = function (app, config, auditLogger) {
         // use loopbacks toJSON to remove circular references from models
         auditLog.result = Array.isArray(context.result)
             ? context.result.map(function (entry) { return entry.toJSON(); })
-            : ((context.result && context.result.toJSON) ? context.result.toJSON() : {});
+            : ((context.result && context.result.toJSON) ? context.result.toJSON()
+                : (context.result) ? JSON.parse(JSON.stringify(context.result)) : {});
         auditLog.error = context.error || {};
         auditLog.status = context.error
             ? (context.error.statusCode || context.error.status || context.res.statusCode)

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -47,14 +47,17 @@ exports.init = function (app, config, auditLogger) {
 
             // $ and . are not allowed as keys in mongo, so escape them all
             var json = JSON.stringify(auditLog);
-            json.match(/("[\$|\.]([^"]|"")*":)/gm).forEach((key) => {
-                json = json.replace(key, key.replace(/\$/g, '___').replace(/\./g, '__'));
-            });
+            var keys = json.match(/("[\$|\.]([^"]|"")*":)/gm);
+            if (keys) {
+                keys.forEach((key) => {
+                    json = json.replace(key, key.replace(/\$/g, '___').replace(/\./g, '__'));
+                });
 
-            try {
-                auditLog = JSON.parse(json);
-            } catch (e) {
-                console.log(json);
+                try {
+                    auditLog = JSON.parse(json);
+                } catch (e) {
+                    console.log(json);
+                }
             }
 
             process.nextTick(function () {
@@ -114,6 +117,10 @@ exports.init = function (app, config, auditLogger) {
     models.forEach(function (Model) {
 
         Model.afterRemote('**', function (context, unused, next) {
+            log(context);
+            next();
+        });
+        Model.afterRemote('prototype.*', function (context, unused, next) {
             log(context);
             next();
         });

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -1,4 +1,5 @@
 'use strict';
+var async = require('async');
 
 exports.init = function (app, config, auditLogger) {
 
@@ -45,28 +46,26 @@ exports.init = function (app, config, auditLogger) {
             auditLog.user = currentUser;
 
             // $ and . are not allowed as keys in mongo, so escape them all
-            auditLog = JSON.parse(JSON.stringify(auditLog).replace(/\$/g, '___').replace(/\./g, '__'));
+            var json = JSON.stringify(auditLog);
+            json.match(/("[\$|\.]([^"]|"")*":)/gm).forEach((key) => {
+                json = json.replace(key, key.replace(/\$/g, '___').replace(/\./g, '__'));
+            });
+
+            try {
+                auditLog = JSON.parse(json);
+            } catch (e) {
+                console.log(json);
+            }
 
             process.nextTick(function () {
-                auditLogger.info({'log': auditLog});
+                auditLogger.info({ 'log': auditLog });
             });
         };
 
         try {
             if (!req.currentUser) {
                 if (req.accessToken) {
-                    app.models.User.findById(
-                        req.accessToken.userId,
-                        function (err, user) {
-                            if (user) {
-                                currentUser = user.toObject();
-                                req.currentUser = currentUser;
-                            } else {
-                                currentUser.name = 'USER NOT FOUND';
-                            }
-                            logWithUser();
-                        }
-                    );
+                    getCurrentUser();
                 } else {
                     currentUser.name = 'ANONYMOUS';
                     logWithUser();
@@ -78,6 +77,36 @@ exports.init = function (app, config, auditLogger) {
         } catch (e) {
             // catch logging error to prevent them from kiling the process
             console.log(e);
+        }
+
+        function getCurrentUser() {
+            var modelsToFind = app.models().filter(model => { return model.base.name === 'User' });
+            modelsToFind.push(app.models.User);
+
+            var funcCalls = [];
+            for (var i = 0; i < modelsToFind.length; i++) {
+                funcCalls.push(findUser.bind(null, i));
+            }
+
+            function findUser(index, callback) {
+                modelsToFind[index].findById(req.accessToken.userId, function (err, user) {
+                    callback(err, user);
+                });
+            }
+
+            async.parallel(funcCalls, function (error, results) {
+                currentUser.name = 'USER NOT FOUND';
+                for (var i = 0; i < results.length; i++) {
+                    var user = results[i];
+                    if (user) {
+                        currentUser = user.toObject();
+                        req.currentUser = currentUser;
+                        break;
+                    }
+                }
+
+                logWithUser();
+            });
         }
     }
 

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -1,5 +1,4 @@
 'use strict';
-var async = require('async');
 
 exports.init = function (app, config, auditLogger) {
 
@@ -26,16 +25,20 @@ exports.init = function (app, config, auditLogger) {
         if (auditLog.arguments.args.res) {
             delete auditLog.arguments.args.res;
         }
+        // fix authorizedRoles with for JSON invalid keys '$...'
+        if (auditLog.arguments.args.options && auditLog.arguments.args.options.authorizedRoles) {
+            auditLog.arguments.args.options.authorizedRoles = Object.keys(auditLog.arguments.args.options.authorizedRoles);
+        }
 
-        // use loopbacks toJSON to remove circular references from models
-        auditLog.result = Array.isArray(context.result)
-            ? context.result.map(function (entry) { return entry.toJSON(); })
-            : ((context.result && context.result.toJSON) ? context.result.toJSON()
-                : (context.result) ? JSON.parse(JSON.stringify(context.result)) : {});
+        auditLog.result = Array.isArray(context.result) ?
+            context.result.map(function (entry) {
+                return entry.toJSON();
+            }) : ((context.result && context.result.toJSON) ?
+                context.result.toJSON() : {});
         auditLog.error = context.error || {};
-        auditLog.status = context.error
-            ? (context.error.statusCode || context.error.status || context.res.statusCode)
-            : (context.result && Object.keys(context.result) > 0 ? 200 : 204);
+        auditLog.status = context.error ?
+            (context.error.statusCode || context.error.status || context.res.statusCode) :
+            (context.result && Object.keys(context.result) > 0 ? 200 : 204);
 
         var currentUser = {};
 
@@ -46,21 +49,6 @@ exports.init = function (app, config, auditLogger) {
                 undefined;
             auditLog.user = currentUser;
 
-            // $ and . are not allowed as keys in mongo, so escape them all
-            var json = JSON.stringify(auditLog);
-            var keys = json.match(/("[\$|\.]([^"]|"")*":)/gm);
-            if (keys) {
-                keys.forEach((key) => {
-                    json = json.replace(key, key.replace(/\$/g, '___').replace(/\./g, '__'));
-                });
-
-                try {
-                    auditLog = JSON.parse(json);
-                } catch (e) {
-                    console.log(json);
-                }
-            }
-
             process.nextTick(function () {
                 auditLogger.info({ 'log': auditLog });
             });
@@ -69,7 +57,18 @@ exports.init = function (app, config, auditLogger) {
         try {
             if (!req.currentUser) {
                 if (req.accessToken) {
-                    getCurrentUser();
+                    app.models.User.findById(
+                        req.accessToken.userId,
+                        function (err, user) {
+                            if (user) {
+                                currentUser = user.toObject();
+                                req.currentUser = currentUser;
+                            } else {
+                                currentUser.name = 'USER NOT FOUND';
+                            }
+                            logWithUser();
+                        }
+                    );
                 } else {
                     currentUser.name = 'ANONYMOUS';
                     logWithUser();
@@ -82,47 +81,23 @@ exports.init = function (app, config, auditLogger) {
             // catch logging error to prevent them from kiling the process
             console.log(e);
         }
+    }
 
-        function getCurrentUser() {
-            var modelsToFind = app.models().filter(model => { return model.base.name === 'User' });
-            modelsToFind.push(app.models.User);
-
-            var funcCalls = [];
-            for (var i = 0; i < modelsToFind.length; i++) {
-                funcCalls.push(findUser.bind(null, i));
-            }
-
-            function findUser(index, callback) {
-                modelsToFind[index].findById(req.accessToken.userId, function (err, user) {
-                    callback(err, user);
-                });
-            }
-
-            async.parallel(funcCalls, function (error, results) {
-                currentUser.name = 'USER NOT FOUND';
-                for (var i = 0; i < results.length; i++) {
-                    var user = results[i];
-                    if (user) {
-                        currentUser = user.toObject();
-                        req.currentUser = currentUser;
-                        break;
-                    }
-                }
-
-                logWithUser();
-            });
-        }
+    function filter(context) {
+        return !config || !config.filter || config.filter(context);
     }
 
     var models = app.models();
     models.forEach(function (Model) {
 
         Model.afterRemote('**', function (context, unused, next) {
-            log(context);
+            if (filter(context))
+                log(context);
             next();
         });
         Model.afterRemote('prototype.*', function (context, unused, next) {
-            log(context);
+            if (filter(context))
+                log(context);
             next();
         });
         Model.afterRemoteError('**', function (context, next) {

--- a/lib/loopbackHook.js
+++ b/lib/loopbackHook.js
@@ -33,8 +33,8 @@ exports.init = function (app, config, auditLogger) {
         auditLog.result = Array.isArray(context.result) ?
             context.result.map(function (entry) {
                 return entry.toJSON();
-            }) : ((context.result && context.result.toJSON) ?
-                context.result.toJSON() : {});
+            }) : ((context.result && context.result.toJSON) ? context.result.toJSON()
+                : (context.result) ? JSON.parse(JSON.stringify(context.result)) : {});
         auditLog.error = context.error || {};
         auditLog.status = context.error ?
             (context.error.statusCode || context.error.status || context.res.statusCode) :


### PR DESCRIPTION
Execute parallel find in all model that extends from User.
Added **prototype.*** afterRemote to log remote methods.
Replace **$** and **.** just on json keys to preserve the content.